### PR TITLE
gems: Update rails to 6.0.3.1 because of CVE-2020-8165.

### DIFF
--- a/multi_version_common_cartridge.gemspec
+++ b/multi_version_common_cartridge.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     file.match(%r{^(test|spec|features)/})
   end
 
-  spec.add_dependency 'activesupport', '> 2.0', '< 6.0'
+  spec.add_dependency 'activesupport', '~> 6.0.3.1'
   spec.add_dependency 'common_cartridge_parser', '1.0.0'
 
   spec.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
https://vistahl.atlassian.net/browse/MAE-52732