### PR TITLE
MAE-63004 Included support for launch_url so CCs work in Moodle

### DIFF
--- a/lib/multi_version_common_cartridge/resources/basic_lti_link.rb
+++ b/lib/multi_version_common_cartridge/resources/basic_lti_link.rb
@@ -22,7 +22,7 @@ module MultiVersionCommonCartridge
       end
 
       class BasicLtiLink < MultiVersionCommonCartridge::Resources::Resource
-        attr_accessor :title, :description, :secure_launch_url, :extensions
+        attr_accessor :title, :description, :secure_launch_url, :extensions, :launch_url
 
         def initialize
           @extensions = []

--- a/lib/multi_version_common_cartridge/writers/basic_lti_link_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/basic_lti_link_writer.rb
@@ -200,6 +200,7 @@ module MultiVersionCommonCartridge
             element.xsi_schema_location = xsi_schema_location
             element.title = resource.title
             element.description = resource.description if resource.description
+            element.launch_url = resource.secure_launch_url
             element.secure_launch_url = resource.secure_launch_url
             element.vendor = vendor_writer.vendor_element
             element.extensions = extensions_element

--- a/lib/multi_version_common_cartridge/writers/manifest_organization_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/manifest_organization_writer.rb
@@ -44,7 +44,7 @@ module MultiVersionCommonCartridge
 
       def organization_element
         CommonCartridge::Elements::Organizations::Organization.new.tap do |element|
-          element.identifier = ''
+          element.identifier = 'VHL_' + SecureRandom.uuid
           element.structure = ORGANIZATION_STRUCTURE
           element.root_item = root_item
         end

--- a/spec/lib/writers/basic_lti_link_writer_spec.rb
+++ b/spec/lib/writers/basic_lti_link_writer_spec.rb
@@ -51,6 +51,7 @@ describe MultiVersionCommonCartridge::Writers::BasicLtiLinkWriter do
       it 'creates a random identifier' do
         basic_lti_link.title = title
         basic_lti_link.secure_launch_url = secure_launch_url
+        basic_lti_link.launch_url = secure_launch_url
         basic_lti_link_writer.finalize
         expect(basic_lti_link.identifier).not_to be_empty
       end
@@ -61,6 +62,7 @@ describe MultiVersionCommonCartridge::Writers::BasicLtiLinkWriter do
         basic_lti_link.identifier = identifier
         basic_lti_link.title = title
         basic_lti_link.secure_launch_url = secure_launch_url
+        basic_lti_link.launch_url = secure_launch_url
         basic_lti_link_writer.finalize
         expect(basic_lti_link.identifier).to eq(identifier)
       end
@@ -70,6 +72,7 @@ describe MultiVersionCommonCartridge::Writers::BasicLtiLinkWriter do
       it 'raises an error' do
         basic_lti_link.identifier = identifier
         basic_lti_link.secure_launch_url = secure_launch_url
+        basic_lti_link.launch_url = secure_launch_url
         expect { basic_lti_link_writer.finalize }.to raise_error(
           StandardError,
           described_class::MESSAGES[:no_title]
@@ -82,6 +85,7 @@ describe MultiVersionCommonCartridge::Writers::BasicLtiLinkWriter do
         basic_lti_link.identifier = identifier
         basic_lti_link.title = title
         basic_lti_link.secure_launch_url = secure_launch_url
+        basic_lti_link.launch_url = secure_launch_url
         expect { basic_lti_link_writer.finalize }.not_to raise_error
       end
     end
@@ -90,6 +94,7 @@ describe MultiVersionCommonCartridge::Writers::BasicLtiLinkWriter do
       basic_lti_link.identifier = identifier
       basic_lti_link.title = title
       basic_lti_link.secure_launch_url = secure_launch_url
+      basic_lti_link.launch_url = secure_launch_url
       basic_lti_link_writer.finalize
       expect(vendor_writer).to have_received(:finalize)
     end
@@ -218,6 +223,10 @@ describe MultiVersionCommonCartridge::Writers::BasicLtiLinkWriter do
 
       it 'sets the basic lti link element secure launch url' do
         expect(lti_element.secure_launch_url).to eq(secure_launch_url)
+      end
+
+      it 'sets the basic lti link element launch url' do
+        expect(lti_element.launch_url).to eq(secure_launch_url)
       end
 
       it 'sets the basic lti link element vendor' do


### PR DESCRIPTION
**JIRA link**: https://vistahl.atlassian.net/browse/MAE-63004

### Related PRs
- https://github.com/vhl/m3/pull/9838

### Release PRS
- https://github.com/vhl/mae/pull/2960
- https://github.com/vhl/common_cartridge_parser/pull/8
- https://github.com/vhl/m3/pull/9829
- https://github.com/vhl/submissions/pull/80
- https://github.com/vhl/ua/pull/2601

NOTE: PR for MAE-62369 https://github.com/vhl/m3/pull/9842 was merged into this branch so it contains all the fixes necessary to load and run an M3 CC in Moodle.