### PR TITLE
gems: allow rails 7.x versions in gemspec

### DIFF
--- a/multi_version_common_cartridge.gemspec
+++ b/multi_version_common_cartridge.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     file.match(%r{^(test|spec|features)/})
   end
 
-  spec.add_dependency 'activesupport', '> 2.0', '< 7.0'
+  spec.add_dependency 'activesupport', '> 2.0', '< 8.0'
   spec.add_dependency 'common_cartridge_parser', '~> 1.0'
 
   spec.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
**JIRA link**: https://vistahl.atlassian.net/browse/MAE-81804

Well that was easy.  I hope. 